### PR TITLE
Add keyword analysis tutorial notebook

### DIFF
--- a/Keyword_Planner_Tutorial.ipynb
+++ b/Keyword_Planner_Tutorial.ipynb
@@ -1,0 +1,290 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3ff799e1",
+   "metadata": {},
+   "source": [
+    "# Google Ads Keyword Ideas from URLs\n",
+    "\n",
+    "This tutorial demonstrates how to fetch keyword ideas from Google Ads Keyword Planner for a list of URLs, aggregate the results, and highlight unique high-value keywords."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b92f6e72",
+   "metadata": {},
+   "source": [
+    "## Install dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb558251",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install google-ads plotly -q"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47d87b9e",
+   "metadata": {},
+   "source": [
+    "## Authenticate with Google Ads\n",
+    "Fill in the path to your service account JSON file and the customer details from your Google Ads account."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c37d02b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import pandas as pd\n",
+    "from google.oauth2 import service_account\n",
+    "from google.ads.googleads.client import GoogleAdsClient\n",
+    "\n",
+    "SERVICE_ACCOUNT_FILE = '/path/to/service_account.json'  # update this\n",
+    "DEVELOPER_TOKEN = 'INSERT_DEVELOPER_TOKEN'\n",
+    "LOGIN_CUSTOMER_ID = 'INSERT_LOGIN_CUSTOMER_ID'\n",
+    "CUSTOMER_ID = 'INSERT_CUSTOMER_ID'\n",
+    "\n",
+    "credentials = service_account.Credentials.from_service_account_file(SERVICE_ACCOUNT_FILE)\n",
+    "client = GoogleAdsClient(credentials=credentials,\n",
+    "                         developer_token=DEVELOPER_TOKEN,\n",
+    "                         login_customer_id=LOGIN_CUSTOMER_ID)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84f43d2e",
+   "metadata": {},
+   "source": [
+    "## Helper function to fetch keyword ideas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "804ff725",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "def get_keyword_ideas_from_url(page_url):\n",
+    "    keyword_plan_idea_service = client.get_service('KeywordPlanIdeaService')\n",
+    "    google_ads_service = client.get_service('GoogleAdsService')\n",
+    "\n",
+    "    language_rn = google_ads_service.language_constant_path('1000')  # English\n",
+    "\n",
+    "    request = client.get_type('GenerateKeywordIdeasRequest')\n",
+    "    request.customer_id = CUSTOMER_ID\n",
+    "    request.language = language_rn\n",
+    "    request.include_adult_keywords = False\n",
+    "    request.keyword_plan_network = client.enums.KeywordPlanNetworkEnum.GOOGLE_SEARCH_AND_PARTNERS\n",
+    "    request.url_seed.url = page_url\n",
+    "\n",
+    "    response = keyword_plan_idea_service.generate_keyword_ideas(request=request)\n",
+    "\n",
+    "    ideas = []\n",
+    "    comp_enum = client.enums.KeywordPlanCompetitionLevelEnum.KeywordPlanCompetitionLevel\n",
+    "    for idea in response.results:\n",
+    "        m = idea.keyword_idea_metrics\n",
+    "        ideas.append({\n",
+    "            'Keyword Text': idea.text,\n",
+    "            'Average Monthly Searches': m.avg_monthly_searches or 0,\n",
+    "            'Competition': comp_enum.Name(m.competition),\n",
+    "            'Competition Index': getattr(m, 'competition_index', 0),\n",
+    "            'URL': page_url\n",
+    "        })\n",
+    "    df = pd.DataFrame(ideas)\n",
+    "    return df.drop_duplicates(subset=['Keyword Text','URL']).reset_index(drop=True)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d799e6f",
+   "metadata": {},
+   "source": [
+    "## Load URLs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b45352f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# CSV file should contain a column named 'URL'\n",
+    "urls_df = pd.read_csv('urls.csv')\n",
+    "all_urls = urls_df['URL'].dropna().astype(str).unique().tolist()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dbabb4c9",
+   "metadata": {},
+   "source": [
+    "## Fetch keyword ideas for each URL"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b6e0fc8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "keyword_dfs = []\n",
+    "for url in all_urls:\n",
+    "    print(f'Fetching keyword ideas for: {url}')\n",
+    "    try:\n",
+    "        df = get_keyword_ideas_from_url(url)\n",
+    "        if not df.empty:\n",
+    "            keyword_dfs.append(df)\n",
+    "    except Exception as e:\n",
+    "        print(f'  -> Error for {url}: {e}')\n",
+    "\n",
+    "combined_df = pd.concat(keyword_dfs, ignore_index=True)\n",
+    "combined_df = combined_df.drop_duplicates(subset=['URL','Keyword Text']).reset_index(drop=True)\n",
+    "\n",
+    "# keyword length\n",
+    "combined_df['KW Length'] = combined_df['Keyword Text'].str.split().str.len()\n",
+    "combined_df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18d892f3",
+   "metadata": {},
+   "source": [
+    "## Aggregate keywords across URLs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1521041",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "kw_rep = combined_df.drop_duplicates(subset='Keyword Text').copy()\n",
+    "kw_count = combined_df.groupby('Keyword Text')['URL'].nunique().reset_index(name='URL Count')\n",
+    "kw_urls = combined_df.groupby('Keyword Text')['URL'].agg(list).reset_index(name='URLs')\n",
+    "keyword_crossurl = (\n",
+    "    kw_rep.merge(kw_count, on='Keyword Text').merge(kw_urls, on='Keyword Text')\n",
+    ")\n",
+    "keyword_crossurl.head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7022db1c",
+   "metadata": {},
+   "source": [
+    "## Filter for unique, high-value keywords"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2e89190",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "filtered = keyword_crossurl[keyword_crossurl['URL Count'] <= 8].copy()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de8effdd",
+   "metadata": {},
+   "source": [
+    "### Weighting formula"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f13bfa05",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "def weighting_formula(avg_monthly_searches, competition_index, url_count):\n",
+    "    return np.log(avg_monthly_searches + 1) * (1 / (competition_index + 1)) * (1 / (url_count + 1))\n",
+    "\n",
+    "filtered['Score'] = filtered.apply(\n",
+    "    lambda row: weighting_formula(row['Average Monthly Searches'], row['Competition Index'], row['URL Count']),\n",
+    "    axis=1\n",
+    ")\n",
+    "filtered = filtered.sort_values('Score', ascending=False).reset_index(drop=True)\n",
+    "filtered.head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35c7e76f",
+   "metadata": {},
+   "source": [
+    "## Visualize results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f503721b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import plotly.express as px\n",
+    "\n",
+    "fig = px.scatter(filtered,\n",
+    "                 x='Average Monthly Searches',\n",
+    "                 y='Competition Index',\n",
+    "                 size='Score',\n",
+    "                 color='URL Count',\n",
+    "                 hover_data=['Keyword Text','Score'],\n",
+    "                 title='Keyword Opportunities')\n",
+    "fig.update_layout(xaxis_range=[0, filtered['Average Monthly Searches'].max()*1.1],\n",
+    "                  yaxis_range=[0, filtered['Competition Index'].max()*1.1])\n",
+    "fig.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f691cf4d",
+   "metadata": {},
+   "source": [
+    "## Save the results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9bf1e67a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "filtered.to_csv('keyword_opportunities.csv', index=False)\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a new tutorial notebook combining keyword retrieval and scoring steps

## Testing
- `python - <<'PY'
import nbformat
nb = nbformat.read('Keyword_Planner_Tutorial.ipynb', as_version=4)
print('cells', len(nb.cells))
PY`


------
https://chatgpt.com/codex/tasks/task_e_6874a315aa84832e926c676654e61056